### PR TITLE
Add uplift tracking to the dashboard

### DIFF
--- a/measurements-dash/dash.js
+++ b/measurements-dash/dash.js
@@ -66,6 +66,14 @@ let bugLists = new Map([
       },
       columns: ["assigned_to", "summary"],
     }],
+    ["uplifts", {
+      category: "active",
+      searchParams: {
+        resolution: "---",
+        whiteboard: "[measurement:client:uplift]",
+      },
+      columns: ["assigned_to", "summary"],
+    }],
     ["project", {
       category: "active",
       searchParams: {


### PR DESCRIPTION
This will enable the [measurement:client:uplift] whiteboard
tag to be tracked by the related uplift section of the
dashboard.